### PR TITLE
Corrected for the error in the "calculate_proportion" function

### DIFF
--- a/R/calculate_proportion.R
+++ b/R/calculate_proportion.R
@@ -27,16 +27,17 @@ calculate_proportion = function( TmbData, Index, Expansion_cz=NULL, Year_Set=NUL
   Index_ctl = array(Index$Index_ctl[,,,'Estimate'],dim=dim(Index$Index_ctl)[1:3])
   SE_Index_ctl = array(Index$Index_ctl[,,,'Std. Error'],dim=dim(Index$Index_ctl)[1:3])
 
-  # Calculate proportions, and total biomass
-  Prop_ctl = Index_ctl / outer(rep(1,dim(Index_ctl)[1]),apply(Index_ctl,MARGIN=2:3,FUN=sum))
-  Index_tl = apply(Index_ctl,MARGIN=2:3,FUN=sum)
-  SE_Index_tl = sqrt(apply(SE_Index_ctl^2,MARGIN=2:3,FUN=sum,na.rm=TRUE))
-
   if( !is.null(Expansion_cz) ){
     Index_ctl = as.array(Index_ctl[Expansion_cz[,1]==1,,,drop=FALSE])
     SE_Index_ctl = as.array(SE_Index_ctl[Expansion_cz[,1]==1,,,drop=FALSE])
     category_names = category_names[Expansion_cz[,1]==1]
   }
+
+  # Calculate proportions, and total biomass
+  Prop_ctl = Index_ctl / outer(rep(1,dim(Index_ctl)[1]),apply(Index_ctl,MARGIN=2:3,FUN=sum))
+  Index_tl = apply(Index_ctl,MARGIN=2:3,FUN=sum)
+  SE_Index_tl = sqrt(apply(SE_Index_ctl^2,MARGIN=2:3,FUN=sum,na.rm=TRUE))
+
 
   # Approximate variance for proportions, and effective sample size
   Neff_ctl = var_Prop_ctl = array(NA,dim=dim(Prop_ctl))


### PR DESCRIPTION
Sorry about that, the order of calculations in the previous version of the "calculate_proportion" function was not right. I corrected for this, and now the PESC demo provided in the VAST Wiki should work perfectly.