### PR TITLE
Northwest Atlantic - subset EPUs

### DIFF
--- a/R/Prepare_XXXX_Extrapolation_Data_Fn.R
+++ b/R/Prepare_XXXX_Extrapolation_Data_Fn.R
@@ -355,6 +355,10 @@ function( strata.limits=NULL, epu_to_use = c('All', 'Georges_Bank','Mid_Atlantic
   }
   message("Using strata ", strata.limits)
 
+  if(tolower(epu_to_use) == "all") {
+    epu_to_use <- c('Georges_Bank','Mid_Atlantic_Bight','Scotian_Shelf','Gulf_of_Maine','Other')
+  }
+
   # Read extrapolation data
   utils::data( northwest_atlantic_grid, package="FishStatsUtils" )
   Data_Extrap <- northwest_atlantic_grid

--- a/R/Prepare_XXXX_Extrapolation_Data_Fn.R
+++ b/R/Prepare_XXXX_Extrapolation_Data_Fn.R
@@ -348,7 +348,7 @@ function( strata.limits=NULL, projargs=NA, zone=NA, flip_around_dateline=FALSE, 
 
 #' @export
 Prepare_NWA_Extrapolation_Data_Fn <-
-function( strata.limits=NULL, epu_to_use = c('Georges_Bank','Mid_Atlantic_Bight','Scotian_Shelf','Gulf_of_Maine','Other')[1], projargs=NA, zone=NA, flip_around_dateline=FALSE, ... ){
+function( strata.limits=NULL, epu_to_use = c('All', 'Georges_Bank','Mid_Atlantic_Bight','Scotian_Shelf','Gulf_of_Maine','Other')[1], projargs=NA, zone=NA, flip_around_dateline=FALSE, ... ){
   # Infer strata
   if( is.null(strata.limits)){
     strata.limits = list('All_areas'=1:1e5)
@@ -402,6 +402,10 @@ function( strata.limits=NULL, projargs=NA, zone=NA, survey="Chatham_rise", flip_
     strata.limits = data.frame('STRATA'="All_areas")
   }
   message("Using strata ", strata.limits)
+
+  if(tolower(epu_to_use) == "all") {
+    epu_to_use <- c('Georges_Bank','Mid_Atlantic_Bight','Scotian_Shelf','Gulf_of_Maine','Other')
+  }
 
   # Read extrapolation data
   utils::data( chatham_rise_grid, package="FishStatsUtils" )

--- a/R/Prepare_XXXX_Extrapolation_Data_Fn.R
+++ b/R/Prepare_XXXX_Extrapolation_Data_Fn.R
@@ -14,7 +14,7 @@ function( strata.limits=NULL, projargs=NA, zone=NA, flip_around_dateline=TRUE, .
 
   # Survey areas
   Area_km2_x = Data_Extrap[,'Area_km2']
-  
+
   # Augment with strata for each extrapolation cell
   Tmp = cbind("BEST_DEPTH_M"=0, "BEST_LAT_DD"=Data_Extrap[,'Lat'], "propInSurvey"=1)
   a_el = as.data.frame(matrix(NA, nrow=nrow(Data_Extrap), ncol=nrow(strata.limits), dimnames=list(NULL,strata.limits[,'STRATA'])))
@@ -348,7 +348,7 @@ function( strata.limits=NULL, projargs=NA, zone=NA, flip_around_dateline=FALSE, 
 
 #' @export
 Prepare_NWA_Extrapolation_Data_Fn <-
-function( strata.limits=NULL, projargs=NA, zone=NA, flip_around_dateline=FALSE, ... ){
+function( strata.limits=NULL, epu_to_use = c('Georges_Bank','Mid_Atlantic_Bight','Scotian_Shelf','Gulf_of_Maine','Other')[1], projargs=NA, zone=NA, flip_around_dateline=FALSE, ... ){
   # Infer strata
   if( is.null(strata.limits)){
     strata.limits = list('All_areas'=1:1e5)
@@ -365,7 +365,8 @@ function( strata.limits=NULL, projargs=NA, zone=NA, flip_around_dateline=FALSE, 
   # Augment with strata for each extrapolation cell
   Tmp = cbind("BEST_DEPTH_M"=0, "BEST_LAT_DD"=Data_Extrap[,'Lat'], "BEST_LON_DD"=Data_Extrap[,'Lon'])
   if( length(strata.limits)==1 && strata.limits[1]=="EPU" ){
-    # Specify strata by 'stratum_number'
+    # Specify epu by 'epu_to_use'
+    Data_Extrap <- Data_Extrap[Data_Extrap$EPU %in% epu_to_use, ]
     a_el = matrix(NA, nrow=nrow(Data_Extrap), ncol=length(unique(northwest_atlantic_grid[,'EPU'])), dimnames=list(NULL,unique(northwest_atlantic_grid[,'EPU'])) )
     for(l in 1:ncol(a_el)){
       a_el[,l] = ifelse( Data_Extrap[,'EPU']==unique(northwest_atlantic_grid[,'EPU'])[l], Area_km2_x, 0 )

--- a/R/Prepare_XXXX_Extrapolation_Data_Fn.R
+++ b/R/Prepare_XXXX_Extrapolation_Data_Fn.R
@@ -359,21 +359,22 @@ function( strata.limits=NULL, epu_to_use = c('Georges_Bank','Mid_Atlantic_Bight'
   utils::data( northwest_atlantic_grid, package="FishStatsUtils" )
   Data_Extrap <- northwest_atlantic_grid
 
-  # Survey areas
-  Area_km2_x = Data_Extrap[,'Area_in_survey_km2']
-
   # Augment with strata for each extrapolation cell
   Tmp = cbind("BEST_DEPTH_M"=0, "BEST_LAT_DD"=Data_Extrap[,'Lat'], "BEST_LON_DD"=Data_Extrap[,'Lon'])
   if( length(strata.limits)==1 && strata.limits[1]=="EPU" ){
     # Specify epu by 'epu_to_use'
     Data_Extrap <- Data_Extrap[Data_Extrap$EPU %in% epu_to_use, ]
     a_el = matrix(NA, nrow=nrow(Data_Extrap), ncol=length(unique(northwest_atlantic_grid[,'EPU'])), dimnames=list(NULL,unique(northwest_atlantic_grid[,'EPU'])) )
+    Area_km2_x = Data_Extrap[, "Area_in_survey_km2"]
     for(l in 1:ncol(a_el)){
       a_el[,l] = ifelse( Data_Extrap[,'EPU']==unique(northwest_atlantic_grid[,'EPU'])[l], Area_km2_x, 0 )
     }
   }else{
     # Specify strata by 'stratum_number'
     a_el = as.data.frame(matrix(NA, nrow=nrow(Data_Extrap), ncol=length(strata.limits), dimnames=list(NULL,names(strata.limits))))
+
+        # Survey areas
+    Area_km2_x = Data_Extrap[,'Area_in_survey_km2']
     for(l in 1:ncol(a_el)){
       a_el[,l] = ifelse( Data_Extrap[,'stratum_number'] %in% strata.limits[[l]], Area_km2_x, 0 )
     }


### PR DESCRIPTION
Currently, it doesn't seem possible to run a VAST model using the fit_model functions on a specific NWA EPU (e.g., strata.list = "EPU", but just for Georges Bank). I attempted to add this functionality in a similar manner to the BC "strata_to_add" argument, with an "epu_to_add" argument. Not sure my modifications are aligned with your development plan for VAST/FishStatUtils. Conversely, would it be better to run a model for the whole shelf (e.g., strata.list = "All.strata") and subset post hoc? Thanks for your feedback.  