### PR TITLE
Fix NEUS EPUs

### DIFF
--- a/R/Prepare_XXXX_Extrapolation_Data_Fn.R
+++ b/R/Prepare_XXXX_Extrapolation_Data_Fn.R
@@ -371,7 +371,7 @@ function( strata.limits=NULL, epu_to_use = c('All', 'Georges_Bank','Mid_Atlantic
     a_el = matrix(NA, nrow=nrow(Data_Extrap), ncol=length(epu_to_use), dimnames=list(NULL, epu_to_use) )
     Area_km2_x = Data_Extrap[, "Area_in_survey_km2"]
     for(l in 1:ncol(a_el)){
-      a_el[,l] = ifelse( Data_Extrap[,'EPU']==unique(northwest_atlantic_grid[,'EPU'])[l], Area_km2_x, 0 )
+      a_el[,l] = ifelse( Data_Extrap[,'EPU'] %in% epu_to_use[[l]], Area_km2_x, 0 )
     }
   }else{
     # Specify strata by 'stratum_number'

--- a/R/Prepare_XXXX_Extrapolation_Data_Fn.R
+++ b/R/Prepare_XXXX_Extrapolation_Data_Fn.R
@@ -407,10 +407,6 @@ function( strata.limits=NULL, projargs=NA, zone=NA, survey="Chatham_rise", flip_
   }
   message("Using strata ", strata.limits)
 
-  if(tolower(epu_to_use) == "all") {
-    epu_to_use <- c('Georges_Bank','Mid_Atlantic_Bight','Scotian_Shelf','Gulf_of_Maine','Other')
-  }
-
   # Read extrapolation data
   utils::data( chatham_rise_grid, package="FishStatsUtils" )
   Data_Extrap <- chatham_rise_grid

--- a/R/Prepare_XXXX_Extrapolation_Data_Fn.R
+++ b/R/Prepare_XXXX_Extrapolation_Data_Fn.R
@@ -368,6 +368,8 @@ function( strata.limits=NULL, epu_to_use = c('All', 'Georges_Bank','Mid_Atlantic
   if( length(strata.limits)==1 && strata.limits[1]=="EPU" ){
     # Specify epu by 'epu_to_use'
     Data_Extrap <- Data_Extrap[Data_Extrap$EPU %in% epu_to_use, ]
+    Data_Extrap$EPU <- droplevels(Data_Extrap$EPU)
+
     a_el = matrix(NA, nrow=nrow(Data_Extrap), ncol=length(epu_to_use), dimnames=list(NULL, epu_to_use) )
     Area_km2_x = Data_Extrap[, "Area_in_survey_km2"]
     for(l in 1:ncol(a_el)){

--- a/R/Prepare_XXXX_Extrapolation_Data_Fn.R
+++ b/R/Prepare_XXXX_Extrapolation_Data_Fn.R
@@ -355,7 +355,7 @@ function( strata.limits=NULL, epu_to_use = c('All', 'Georges_Bank','Mid_Atlantic
   }
   message("Using strata ", strata.limits)
 
-  if(tolower(epu_to_use) == "all") {
+  if(any(tolower(epu_to_use) %in% "all")) {
     epu_to_use <- c('Georges_Bank','Mid_Atlantic_Bight','Scotian_Shelf','Gulf_of_Maine','Other')
   }
 

--- a/R/Prepare_XXXX_Extrapolation_Data_Fn.R
+++ b/R/Prepare_XXXX_Extrapolation_Data_Fn.R
@@ -368,7 +368,7 @@ function( strata.limits=NULL, epu_to_use = c('All', 'Georges_Bank','Mid_Atlantic
   if( length(strata.limits)==1 && strata.limits[1]=="EPU" ){
     # Specify epu by 'epu_to_use'
     Data_Extrap <- Data_Extrap[Data_Extrap$EPU %in% epu_to_use, ]
-    a_el = matrix(NA, nrow=nrow(Data_Extrap), ncol=length(unique(northwest_atlantic_grid[,'EPU'])), dimnames=list(NULL,unique(northwest_atlantic_grid[,'EPU'])) )
+    a_el = matrix(NA, nrow=nrow(Data_Extrap), ncol=length(epu_to_use), dimnames=list(NULL, epu_to_use) )
     Area_km2_x = Data_Extrap[, "Area_in_survey_km2"]
     for(l in 1:ncol(a_el)){
       a_el[,l] = ifelse( Data_Extrap[,'EPU']==unique(northwest_atlantic_grid[,'EPU'])[l], Area_km2_x, 0 )

--- a/R/make_extrapolation_info.R
+++ b/R/make_extrapolation_info.R
@@ -20,6 +20,7 @@
 #' @param grid_dim_LL same as \code{grid_dim_km} except measured in latitude-longitude coordinates; only used if \code{Region="other"}
 #' @param grid_in_UTM Boolean stating whether to automatically generate an extrapolation grid based on sampling locations in km within the UTM projection of within Lat-Lon coordinates; only used if \code{Region="other"}
 #' @param strata_to_use strata to include by default for the BC coast extrapolation grid; only used if \code{Region="british_columbia"}
+#' @param epu_to_use EPU to include for the Northwest Atlantic (NWA) extrapolation grid, default is "All"; only used if \code{Region="northwest_atlantic"}
 #' @param survey survey to use for New Zealand extrapolation grid; only used if \code{Region="new_zealand"}
 #' @param region which coast to use for South Africa extrapolation grid; only used if \code{Region="south_africa"}
 #' @param surveyname area of West Coast to include in area-weighted extrapolation for California Current; only used if \code{Region="california_current"}
@@ -40,6 +41,7 @@ make_extrapolation_info = function( Region, projargs=NA, zone=NA, strata.limits=
   create_strata_per_region=FALSE, max_cells=Inf, input_grid=NULL, observations_LL=NULL, grid_dim_km=c(2,2),
   maximum_distance_from_sample=NULL, grid_in_UTM=TRUE, grid_dim_LL=c(0.1,0.1),
   region=c("south_coast","west_coast"), strata_to_use=c('SOG','WCVI','QCS','HS','WCHG'),
+  epu_to_use=c('All','Georges_Bank','Mid_Atlantic_Bight','Scotian_Shelf','Gulf_of_Maine','Other')[1],
   survey="Chatham_rise", surveyname='propInWCGBTS', flip_around_dateline, nstart=100, ... ){
 
   # Note: flip_around_dateline must appear in arguments for argument-matching in fit_model
@@ -85,7 +87,7 @@ make_extrapolation_info = function( Region, projargs=NA, zone=NA, strata.limits=
     }
     if( tolower(Region[rI]) == "northwest_atlantic" ){
       if(missing(flip_around_dateline)) flip_around_dateline = FALSE
-      Extrapolation_List = Prepare_NWA_Extrapolation_Data_Fn( strata.limits=strata.limits, projargs=projargs, zone=zone, flip_around_dateline=flip_around_dateline, ... )
+      Extrapolation_List = Prepare_NWA_Extrapolation_Data_Fn( strata.limits=strata.limits, epu_to_use=epu_to_use, projargs=projargs, zone=zone, flip_around_dateline=flip_around_dateline, ... )
     }
     if( tolower(Region[rI]) == "south_africa" ){
       if(missing(flip_around_dateline)) flip_around_dateline = FALSE


### PR DESCRIPTION
This pull request adds new functionality and fixes a few errors that slipped through the last pull request. Let me know if you have any questions!

New functionality: 
* Allow for multiple EPUs to be selected, e.g., epu_to_use = c("Georges_Bank", "Gulf_of_Maine")
* Add epu_to_use argument to make_extrapolation_info so it is exported via formalArgs().

Fixed errors:
* I accidently added the epu_to_use argument to Prepare_NZ_Extrapolation_Data_Fn() in addition to Prepare_NWA_Extrapolation_Data_Fn() 
* Fix bug that returned all EPUs instead of epu_to_use 
* Made for-loop index consistent for multiple EPUS and  drop unused levels of EPUs