### PR TITLE
Streamline make_kmeans to avoid recalculation of extrapolation grid and improve console output

### DIFF
--- a/R/make_extrapolation_info.R
+++ b/R/make_extrapolation_info.R
@@ -230,7 +230,7 @@ make_extrapolation_info = function( Region, projargs=NA, zone=NA, strata.limits=
     loc_orig = Return$Data_Extrap[,c("E_km","N_km")]
       loc_orig = loc_orig[ which(Return$Area_km2_x>0), ]
     Kmeans = make_kmeans( n_x=max_cells, loc_orig=loc_orig, nstart=nstart,
-      randomseed=1, iter.max=1000, DirPath=paste0(getwd(),"/"), Save_Results=TRUE, purpose='extrapolation',
+      randomseed=1, iter.max=1000, DirPath=paste0(getwd(),"/"), Save_Results=TRUE, kmeans_purpose='extrapolation',
       backwards_compatible_kmeans=backwards_compatible_kmeans )
     Kmeans[["cluster"]] = RANN::nn2( data=Kmeans[["centers"]], query=Return$Data_Extrap[,c("E_km","N_km")], k=1)$nn.idx[,1]
     # Transform Extrapolation_List

--- a/R/make_extrapolation_info.R
+++ b/R/make_extrapolation_info.R
@@ -230,7 +230,7 @@ make_extrapolation_info = function( Region, projargs=NA, zone=NA, strata.limits=
     loc_orig = Return$Data_Extrap[,c("E_km","N_km")]
       loc_orig = loc_orig[ which(Return$Area_km2_x>0), ]
     Kmeans = make_kmeans( n_x=max_cells, loc_orig=loc_orig, nstart=nstart,
-      randomseed=1, iter.max=1000, DirPath=paste0(getwd(),"/"), Save_Results=FALSE,
+      randomseed=1, iter.max=1000, DirPath=paste0(getwd(),"/"), Save_Results=TRUE, purpose='extrapolation',
       backwards_compatible_kmeans=backwards_compatible_kmeans )
     Kmeans[["cluster"]] = RANN::nn2( data=Kmeans[["centers"]], query=Return$Data_Extrap[,c("E_km","N_km")], k=1)$nn.idx[,1]
     # Transform Extrapolation_List

--- a/R/make_kmeans.R
+++ b/R/make_kmeans.R
@@ -10,7 +10,7 @@
 #' @param iter.max the number of iterations used per k-means algorithm (default=1000)
 #' @param DirPath a directory where the algorithm looks for a previously-saved output (default is working directory)
 #' @param Save_Results a boolean stating whether to save the output (Default=TRUE)
-#' @param purpose a character representing whether the call is to calculate "extrapolation" or "spatial" information
+#' @param kmeans_purpose a character representing whether the call is to calculate "extrapolation" or "spatial" information
 #' @param backwards_compatible_kmeans a boolean stating how to deal with changes in the kmeans algorithm implemented in R version 3.6.0,
 #'        where \code{backwards_compatible_kmeans==TRUE} modifies the default algorithm to maintain backwards compatibility, and
 #'        where \code{backwards_compatible_kmeans==FALSE} breaks backwards compatibility between R versions prior to and after R 3.6.0.
@@ -24,7 +24,7 @@
 #' @export
 make_kmeans <-
 function( n_x, loc_orig, nstart=100, randomseed=1, iter.max=1000, DirPath=paste0(getwd(),"/"),
-  Save_Results=TRUE, purpose="spatial", backwards_compatible_kmeans=FALSE ){
+  Save_Results=TRUE, kmeans_purpose="spatial", backwards_compatible_kmeans=FALSE ){
 
   # get old seed
   oldseed = ceiling(runif(1,min=1,max=1e6))
@@ -34,13 +34,13 @@ function( n_x, loc_orig, nstart=100, randomseed=1, iter.max=1000, DirPath=paste0
   options( "warn" = -1 )
   on.exit( options(old.options) )
 
-  if(purpose=="spatial"){
-    tmpfile <- paste0("Kmeans-",n_x,".RData")
-  } else if(purpose=="extrapolation"){
+  if(kmeans_purpose=="spatial"){
+    tmpfile <- paste0("Kmeans_knots-",n_x,".RData")
+  } else if(kmeans_purpose=="extrapolation"){
     ## n_x is really max_cells in this case
     tmpfile <- paste0("Kmeans_extrapolation-",n_x,".RData")
   } else {
-    stop("Invalid purpose for make_kmeans:", purpose)
+    stop("Invalid kmeans_purpose for make_kmeans:", kmeans_purpose)
   }
 
   # Backwards compatibility

--- a/R/make_kmeans.R
+++ b/R/make_kmeans.R
@@ -47,7 +47,7 @@ function( n_x, loc_orig, nstart=100, randomseed=1, iter.max=1000, DirPath=paste0
   if( backwards_compatible_kmeans==TRUE ){
     if( identical(formalArgs(RNGkind), c("kind","normal.kind","sample.kind")) ){
       RNGkind_orig = RNGkind()
-      on.exit( RNGkind(kind=RNGkind_orig[1], xnormal.kind=RNGkind_orig[2], sample.kind=RNGkind_orig[3]), add=TRUE )
+      on.exit( RNGkind(kind=RNGkind_orig[1], normal.kind=RNGkind_orig[2], sample.kind=RNGkind_orig[3]), add=TRUE )
       RNGkind( sample.kind="Rounding" )
     }else if( !identical(formalArgs(RNGkind), c("kind","normal.kind")) ){
       stop("Assumptions about `RNGkind` are not met within `make_kmeans`; please report problem to package developers")

--- a/R/make_kmeans.R
+++ b/R/make_kmeans.R
@@ -68,17 +68,25 @@ function( n_x, loc_orig, nstart=100, randomseed=1, iter.max=1000, DirPath=paste0
       message( "Loaded from ", DirPath, tmpfile)
     }else{
       # Multiple runs to find optimal knots
+      message("Using ", nstart, " iterations to find optimal ",
+              ifelse(kmeans_purpose=="extrapolation", "extrapolation grid", "spatial knot"),
+              " placement because no saved file found...")
       Kmeans = list( "tot.withinss"=Inf )
+      tries <- 1
       for(i in 1:nstart){
         Tmp = stats::kmeans( x=loc_orig, centers=n_x, iter.max=iter.max, nstart=1, trace=0)
-        message( 'Num=',i,' Current_Best=',round(Kmeans$tot.withinss,1),' New=',round(Tmp$tot.withinss,1) )#,' Time=',round(Time,4)) )
+        if(i==1) message("Iter=1: Current=", round(Tmp$tot.withinss,0))
+        if(i!=1 & i!=nstart & i %% 10 ==0)
+          message( 'Iter=',i,': Current=',round(Kmeans$tot.withinss,0),' Proposed=',round(Tmp$tot.withinss,0) )#,' Time=',round(Time,4)) )
         if( Tmp$tot.withinss < Kmeans$tot.withinss ){
           Kmeans = Tmp
+          tries <- i # which iteration was the optimal
         }
       }
+      message("Iter=", nstart, ': Final=', round(Kmeans$tot.withinss,0), " after ", tries, " iterations")
       if(Save_Results==TRUE){
         save( Kmeans, file=paste0(DirPath, tmpfile))
-        message( "Calculated and saved to ", DirPath, tmpfile )
+        message( "Results saved to ", DirPath, tmpfile, "\n for subsequent runs by default (delete it to override)")
       }
     }
   }

--- a/R/make_kmeans.R
+++ b/R/make_kmeans.R
@@ -47,7 +47,7 @@ function( n_x, loc_orig, nstart=100, randomseed=1, iter.max=1000, DirPath=paste0
   if( backwards_compatible_kmeans==TRUE ){
     if( identical(formalArgs(RNGkind), c("kind","normal.kind","sample.kind")) ){
       RNGkind_orig = RNGkind()
-      on.exit( RNGkind(kind=RNGkind_orig[1], normal.kind=RNGkind_orig[2], sample.kind=RNGkind_orig[3]), add=TRUE )
+      on.exit( RNGkind(kind=RNGkind_orig[1], xnormal.kind=RNGkind_orig[2], sample.kind=RNGkind_orig[3]), add=TRUE )
       RNGkind( sample.kind="Rounding" )
     }else if( !identical(formalArgs(RNGkind), c("kind","normal.kind")) ){
       stop("Assumptions about `RNGkind` are not met within `make_kmeans`; please report problem to package developers")
@@ -64,8 +64,8 @@ function( n_x, loc_orig, nstart=100, randomseed=1, iter.max=1000, DirPath=paste0
   }else{
     if(tmpfile  %in% list.files(DirPath) ){
       # If previously saved knots are available
-      load( file=file.path(DirPath, tmpfile))
-      message( "Loaded from ",DirPath,"/",tmpfile)
+      load( file=paste0(DirPath, tmpfile))
+      message( "Loaded from ", DirPath, tmpfile)
     }else{
       # Multiple runs to find optimal knots
       Kmeans = list( "tot.withinss"=Inf )
@@ -77,8 +77,8 @@ function( n_x, loc_orig, nstart=100, randomseed=1, iter.max=1000, DirPath=paste0
         }
       }
       if(Save_Results==TRUE){
-        save( Kmeans, file=paste0(DirPath,"/",tmpfile))
-        message( "Calculated and saved to ",DirPath,"/","Kmeans-",n_x,".RData" )
+        save( Kmeans, file=paste0(DirPath, tmpfile))
+        message( "Calculated and saved to ", DirPath, tmpfile )
       }
     }
   }

--- a/R/make_spatial_info.R
+++ b/R/make_spatial_info.R
@@ -106,7 +106,7 @@ make_spatial_info = function( n_x,
 
     # Calculate k-means centroids
     if(is.null(Kmeans)) Kmeans = make_kmeans(n_x=n_x,
-    loc_orig=loc_i[,c("Lon", "Lat")], randomseed=randomseed, purpose='spatial', backwards_compatible_kmeans=backwards_compatible_kmeans, ... )
+    loc_orig=loc_i[,c("Lon", "Lat")], randomseed=randomseed, kmeans_purpose='spatial', backwards_compatible_kmeans=backwards_compatible_kmeans, ... )
 
     # Calculate grid for 2D AR1 process
     loc_grid = expand.grid( 'Lon'=seq(Grid_bounds[1,1],Grid_bounds[2,1],by=grid_size_LL), 'Lat'=seq(Grid_bounds[1,2],Grid_bounds[2,2],by=grid_size_LL) )

--- a/R/make_spatial_info.R
+++ b/R/make_spatial_info.R
@@ -105,8 +105,8 @@ make_spatial_info = function( n_x,
     Grid_bounds = (grid_size_km/110) * apply(loc_e/(grid_size_km/110), MARGIN=2, FUN=function(vec){trunc(range(vec))+c(0,1)})
 
     # Calculate k-means centroids
-    if(is.null(Kmeans)) Kmeans = make_kmeans(n_x=n_x, loc_orig=loc_i[,c("Lon", "Lat")], randomseed=randomseed,
-      backwards_compatible_kmeans=backwards_compatible_kmeans, ... )
+    if(is.null(Kmeans)) Kmeans = make_kmeans(n_x=n_x,
+    loc_orig=loc_i[,c("Lon", "Lat")], randomseed=randomseed, purpose='spatial', backwards_compatible_kmeans=backwards_compatible_kmeans, ... )
 
     # Calculate grid for 2D AR1 process
     loc_grid = expand.grid( 'Lon'=seq(Grid_bounds[1,1],Grid_bounds[2,1],by=grid_size_LL), 'Lat'=seq(Grid_bounds[1,2],Grid_bounds[2,2],by=grid_size_LL) )


### PR DESCRIPTION
Change `make_kmeans` so that it saves the extrapolation results to file and reads it in similar to how it deals with the spatial knot calculations. The two files are now Kmeans_knots-<n_x>.RData and Kmeans_extrapolation-<max_cells>.RData in the working directory. 

This avoids the somewhat slow step of calculating the extrapolation cells when using `finescale=TRUE` and `max_cells` less than the number of extrapolation points, which is the default setting in the common purpose "index2" in `make_settings`. 

In addition the console output was shortened a bit and tweaked to slightly more informative to the user. 

See discussion at issue https://github.com/James-Thorson-NOAA/VAST/issues/248