### PR TITLE
Changes in load_example.R for all examples to work

### DIFF
--- a/R/load_example.R
+++ b/R/load_example.R
@@ -60,7 +60,7 @@ load_example = function( data_set="EBS_pollock" ){
 
   # Initialize all objects as NULL
   Predator_biomass_cath_rate_data = Stomach_content_data =
-    input_grid = covariate_data = F_ct = X_xtp = X_gtp = X_itp = Q_ik = Predator_biomass_cath_rate_data = Stomach_content_data = NULL
+    input_grid = Predator_biomass_cath_rate_data = Stomach_content_data = covariate_data = F_ct = X_xtp = X_gtp = X_itp = Q_ik = NULL
 
   if( tolower(data_set) %in% tolower("WCGBTS_canary") ){
     data( WCGBTS_Canary_example, package="FishStatsUtils" )

--- a/R/load_example.R
+++ b/R/load_example.R
@@ -60,7 +60,7 @@ load_example = function( data_set="EBS_pollock" ){
 
   # Initialize all objects as NULL
   Predator_biomass_cath_rate_data = Stomach_content_data =
-    input_grid = Predator_biomass_cath_rate_data = Stomach_content_data = covariate_data = F_ct = X_xtp = X_gtp = X_itp = Q_ik = NULL
+    input_grid = Predator_biomass_cath_rate_data = F_ct = X_xtp = X_gtp = X_itp = Q_ik = Stomach_content_data = covariate_data = NULL
 
   if( tolower(data_set) %in% tolower("WCGBTS_canary") ){
     data( WCGBTS_Canary_example, package="FishStatsUtils" )

--- a/R/load_example.R
+++ b/R/load_example.R
@@ -60,7 +60,7 @@ load_example = function( data_set="EBS_pollock" ){
 
   # Initialize all objects as NULL
   Predator_biomass_cath_rate_data = Stomach_content_data =
-    input_grid = covariate_data = F_ct = X_xtp = X_gtp = X_itp = Q_ik = NULL
+    input_grid = covariate_data = F_ct = X_xtp = X_gtp = X_itp = Q_ik = Predator_biomass_cath_rate_data = Stomach_content_data = NULL
 
   if( tolower(data_set) %in% tolower("WCGBTS_canary") ){
     data( WCGBTS_Canary_example, package="FishStatsUtils" )


### PR DESCRIPTION
In December 2020, I introduced the "Predator_biomass_cath_rate_data" and "Stomach_content_data" elements in the "Return" list, but forgot to set the "Predator_biomass_cath_rate_data" and "Stomach_content_data" objects to NULL in lines 62-63. I just corrected for this mistake. 
My apologies, and please accept the changes I just introduced in the "load_example.R" file so that VAST users are able to run all examples on their machine.
Many thanks!