### PR TITLE
Add option to specify the path in get_latest_version so it works with CI and locally

### DIFF
--- a/R/get_latest_version.R
+++ b/R/get_latest_version.R
@@ -28,7 +28,7 @@ get_latest_version <- function(version = NULL, package = "VAST", path=NULL) {
     thedir <- system.file("executables", package = package)
   }
 
-  if(thedir==""){
+  if(thedir=="")
     stop("Could not find an executables folder for ", package,
          "\n Something is likely wrong with the installation. Try manually specifiying\n",
          "the version number, or try reinstalling ", package)

--- a/R/get_latest_version.R
+++ b/R/get_latest_version.R
@@ -15,6 +15,11 @@ get_latest_version <- function(version = NULL, package = "VAST") {
 
   # Determine location of files on machine
   thedir <- system.file("executables", package = package)
+  if(thedir==""){
+    stop("Could not find an executables folder for", package,
+         "\n Something is likely wrong with the installation. Try manually specifiying\n",
+         "the version number, or try reinstalling", package)
+  }
 
   # Determine list of available files
   if (!is.null(version)) {

--- a/R/get_latest_version.R
+++ b/R/get_latest_version.R
@@ -16,9 +16,9 @@ get_latest_version <- function(version = NULL, package = "VAST") {
   # Determine location of files on machine
   thedir <- system.file("executables", package = package)
   if(thedir==""){
-    stop("Could not find an executables folder for", package,
+    stop("Could not find an executables folder for ", package,
          "\n Something is likely wrong with the installation. Try manually specifiying\n",
-         "the version number, or try reinstalling", package)
+         "the version number, or try reinstalling ", package)
   }
 
   # Determine list of available files

--- a/R/get_latest_version.R
+++ b/R/get_latest_version.R
@@ -1,9 +1,13 @@
 #' Determine latest version of VAST
 #'
-#' @param version The default is \code{NULL}, which will cause the function
-#' to look for the latest version of the \code{.cpp} file to compile.
-#' If a version is supplied, then \code{R} will look for that version name
-#' within the appropriate folder the disk.
+#' @param version The default is \code{NULL}, which will cause
+#'   the function to look for the latest version of the
+#'   \code{.cpp} file to compile.  If a version is supplied, then
+#'   \code{R} will look for that version name within the
+#'   appropriate folder the disk.
+#' @param path Optional path for running tests locally and with
+#'   continuous integration since the default looks in the wrong
+#'   place (installed library).
 #'
 #' @return A full file path as a character value supplying the location of
 #' the latest, or supplied, version of the VAST code to compile.
@@ -11,14 +15,20 @@
 #' @author Kelli Faye Johnson
 #'
 #' @export
-get_latest_version <- function(version = NULL, package = "VAST") {
+get_latest_version <- function(version = NULL, package = "VAST", path=NULL) {
 
   # Determine location of files on machine
-  thedir <- system.file("executables", package = package)
-  if(thedir==""){
-    stop("Could not find an executables folder for ", package,
-         "\n Something is likely wrong with the installation. Try manually specifiying\n",
-         "the version number, or try reinstalling ", package)
+  if(is.null(path)){
+    thedir <- system.file("executables", package = package)
+    if(thedir==""){
+      stop("Could not find an executables folder for ", package,
+           "\n Something is likely wrong with the installation. Try manually specifiying\n",
+           "the version number, or try reinstalling ", package)
+    }
+  } else {
+    thedir <- path
+    if(!dir.exists(path))
+      stop("Manually specified path to executables is not valid")
   }
 
   # Determine list of available files

--- a/R/get_latest_version.R
+++ b/R/get_latest_version.R
@@ -18,18 +18,20 @@
 get_latest_version <- function(version = NULL, package = "VAST", path=NULL) {
 
   # Determine location of files on machine
-  if(is.null(path)){
-    thedir <- system.file("executables", package = package)
-    if(thedir==""){
-      stop("Could not find an executables folder for ", package,
-           "\n Something is likely wrong with the installation. Try manually specifiying\n",
-           "the version number, or try reinstalling ", package)
+  if(!is.null(path)){
+    thedir <- path
+    if(!dir.exists(path)){
+      warning("Manually specified path to executables is not valid, trying system files")
+      thedir <- system.file("executables", package = package)
     }
   } else {
-    thedir <- path
-    if(!dir.exists(path))
-      stop("Manually specified path to executables is not valid")
+    thedir <- system.file("executables", package = package)
   }
+
+  if(thedir==""){
+    stop("Could not find an executables folder for ", package,
+         "\n Something is likely wrong with the installation. Try manually specifiying\n",
+         "the version number, or try reinstalling ", package)
 
   # Determine list of available files
   if (!is.null(version)) {

--- a/man/make_extrapolation_info.Rd
+++ b/man/make_extrapolation_info.Rd
@@ -68,7 +68,7 @@ make_extrapolation_info(
   \item{\code{"other"}}{Automated creation of an extrapolation-grid by padding an area around observations (not recommended for operational use)}
 }}
 
-\item{projargs}{A character string of projection arguments; the arguments must be entered exactly as in the PROJ.4 documentation; if the projection is unknown, use \code{as.character(NA)}, it may be missing or an empty string of zero length and will then set to the missing value.}
+\item{projargs}{A character string of projection arguments; the arguments must be entered exactly as in the PROJ.4 documentation; if the projection is unknown, use \code{as.character(NA)}, it may be missing or an empty string of zero length and will then set to the missing value. With \pkg{rgdal} built with PROJ >= 6 and GDAL >= 3, the \code{+init=} key may only be used with value \code{epsg:<code>}. From \pkg{sp} version 1.4-4, the string associated with the SRS_string argument may be entered as-is and will be set as SRS_string if the projargs argument does not begin with a \code{+} (suggested by Mikko Vihtakari).}
 
 \item{zone}{UTM zone used for projecting Lat-Lon to km distances; use \code{zone=NA} by default to automatically detect UTM zone from the location of extrapolation-grid samples}
 

--- a/man/make_settings.Rd
+++ b/man/make_settings.Rd
@@ -88,13 +88,15 @@ make_settings(
 
 \item{RhoConfig}{vector of form \code{c("Beta1"=0,"Beta2"=0,"Epsilon1"=0,"Epsilon2"=0)} specifying whether either intercepts (Beta1 and Beta2)
        or spatio-temporal variation (Epsilon1 and Epsilon2) is structured among time intervals, e.g.
-       for component \code{Epsilon1} indicated in the 3rd slot:
+       for component \code{Epsilon2} indicated in the 4rd slot:
 \describe{
-  \item{\code{RhoConfig[3]=0}}{Each year as fixed effect}
-  \item{\code{RhoConfig[3]=1}}{Each year as an independent and identically distributed random effect, thus estimating the variance as fixed effect}
-  \item{\code{RhoConfig[3]=2}}{Each year as a random effect following a random walk, thus estimating the variance as fixed effect}
-  \item{\code{RhoConfig[3]=3}}{Constant among years as fixed effect}
-  \item{\code{RhoConfig[3]=4}}{Each year as a random effect following a first-order autoregressive process, thus estimating the variance and autocorrelation as fixed effects}
+  \item{\code{RhoConfig[4]=0}}{Each year as fixed effect}
+  \item{\code{RhoConfig[4]=1}}{Each year as an independent and identically distributed random effect, thus estimating the variance as fixed effect}
+  \item{\code{RhoConfig[4]=2}}{Each year as a random effect following a random walk, thus estimating the variance as fixed effect}
+  \item{\code{RhoConfig[4]=3}}{Constant among years as fixed effect}
+  \item{\code{RhoConfig[4]=4}}{Each year as a random effect following a first-order autoregressive process, thus estimating the variance as fixed effects and a single first-order autoregression parameter}
+  \item{\code{RhoConfig[4]=5}}{Each year as a random effect following a first-order autoregressive process, estimating the variance as fixed effects and a separate first-order autoregression parameter for each category}
+  \item{\code{RhoConfig[4]=6}}{Only possible for \code{Epsilon2} or \code{Beta2}, and specifying that that associated hyperparameters parameters have identical values to the first component \code{Epsilon1} or \code{Beta1}}
 }
 If missing, the default is to assume a value of zero for each element (i.e., \code{RhoConfig[1:4]=0})}
 
@@ -115,13 +117,14 @@ see \code{\link[TMB]{sdreport}} and \code{\link[TMBhelper]{fit_tmb}}for details}
   \item{\code{Options["Calculate_Cov_SE"]=TRUE}}{Turns on internal calculation and SE for covariance among categories (i.e. in factor model)}
   \item{\code{Options["Calculate_proportion"]=TRUE}}{Turns on internal calculation and SE for proportion of response within each category (e.g., for calculating proportion-at-age or species turnover)}
   \item{\code{Options["Calculate_Synchrony"]=TRUE}}{Turns on internal calculation and SE for Loreau metric of synchrony (a.k.a. portfolio effects)}
+  \item{\code{Options["report_additional_variables"]=TRUE}}{Export additional variables to \code{Report} object, to use for diagnostics or additional exploration}
 }}
 
 \item{use_anisotropy}{Boolean indicating whether to estimate two additional parameters representing geometric anisotropy}
 
 \item{vars_to_correct}{a character-vector listing which parameters to include for bias-correction, as passed to \code{\link[TMBhelper]{fit_tmb}}}
 
-\item{Version}{Which CPP version to use.  If missing, defaults to latest version using \code{\link[FishStatsUtils]{get_latest_version(package="VAST")}}.
+\item{Version}{Which CPP version to use.  If missing, defaults to latest version using \code{\link[FishStatsUtils]{get_latest_version}}.
 Can be used to specify using an older CPP, to maintain backwards compatibility.}
 
 \item{treat_nonencounter_as_zero}{Boolean indicating whether to treat any year-category combination as having zero biomass when generating abundance indices and resulting compositional estimates}

--- a/man/project_coordinates.Rd
+++ b/man/project_coordinates.Rd
@@ -19,7 +19,7 @@ project_coordinates(
 
 \item{Y}{vector of vertical-coordinates (e.g., latitude by default)}
 
-\item{projargs}{A character string of projection arguments; the arguments must be entered exactly as in the PROJ.4 documentation; if the projection is unknown, use \code{as.character(NA)}, it may be missing or an empty string of zero length and will then set to the missing value.}
+\item{projargs}{A character string of projection arguments; the arguments must be entered exactly as in the PROJ.4 documentation; if the projection is unknown, use \code{as.character(NA)}, it may be missing or an empty string of zero length and will then set to the missing value. With \pkg{rgdal} built with PROJ >= 6 and GDAL >= 3, the \code{+init=} key may only be used with value \code{epsg:<code>}. From \pkg{sp} version 1.4-4, the string associated with the SRS_string argument may be entered as-is and will be set as SRS_string if the projargs argument does not begin with a \code{+} (suggested by Mikko Vihtakari).}
 
 \item{zone}{DEPRECATED INPUT; UTM zone (integer between 1 and 60) or alphanumeric CRS code used by package rgdal to convert latitude-longitude coordinates to projection in kilometers; \code{zone=NA} uses UTM and automatically detects the appropriate zone}
 


### PR DESCRIPTION
To use CI on VAST while using the latest version automatically I needed to update this function, otherwise it errors out looking in the wrong place for the executables. This is required to get VAST to pass CI, and should have no impacts on backwards compatibility. 