### PR TITLE
fit_model and make_covs ready for PR

### DIFF
--- a/R/fit_model.R
+++ b/R/fit_model.R
@@ -105,6 +105,7 @@ function( settings,
           X1config_cp = NULL,
           X2config_cp = NULL,
           covariate_data,
+          contrasts = NULL,
           X1_formula = ~ 0,
           X2_formula = ~ 0,
           Q1config_k = NULL,
@@ -158,7 +159,7 @@ function( settings,
   data_args_default = list("Version"=settings$Version, "FieldConfig"=settings$FieldConfig, "OverdispersionConfig"=settings$OverdispersionConfig,
     "RhoConfig"=settings$RhoConfig, "VamConfig"=settings$VamConfig, "ObsModel"=settings$ObsModel, "c_iz"=c_iz, "b_i"=b_i, "a_i"=a_i, "v_i"=v_i,
     "s_i"=spatial_list$knot_i-1, "t_i"=t_i, "spatial_list"=spatial_list, "Options"=settings$Options, "Aniso"=settings$use_anisotropy,
-    "X1config_cp"=X1config_cp, "X2config_cp"=X2config_cp, "covariate_data"=covariate_data, "X1_formula"=X1_formula, "X2_formula"=X2_formula,
+    "X1config_cp"=X1config_cp, "X2config_cp"=X2config_cp, "covariate_data"=covariate_data, "contrasts"=contrasts, "X1_formula"=X1_formula, "X2_formula"=X2_formula,
     "Q1config_k"=Q1config_k, "Q2config_k"=Q2config_k, "catchability_data"=catchability_data, "Q1_formula"=Q1_formula, "Q2_formula"=Q2_formula )
   data_args_input = combine_lists( input=extra_args, default=data_args_default )  # Do *not* use args_to_use
   data_list = do.call( what=make_data, args=data_args_input )

--- a/R/make_covariates.R
+++ b/R/make_covariates.R
@@ -34,6 +34,7 @@
 make_covariates <-
 function( formula,
           covariate_data,
+          contrasts,
           Year_i,
           spatial_list ){
 
@@ -60,7 +61,7 @@ function( formula,
     # issues arising when both conditions are met:
     # factor(Year) has an interaction with another factor, and
     # betas vary among years (are not constant)
-  Model_matrix = model.matrix( update.formula(formula, ~.+1), data=covariate_df )
+  Model_matrix = model.matrix( update.formula(formula, ~.+1), data=covariate_df,  contrasts.arg=contrasts )
   Columns_to_keep = which( attr(Model_matrix,"assign") != 0 )
   coefficient_names = attr(Model_matrix,"dimnames")[[2]][Columns_to_keep]
   X = Model_matrix[,Columns_to_keep,drop=FALSE]


### PR DESCRIPTION
Adding capacity for users to supply factor covariate contrasts and facilitate fitting sub-annual models with a contrasts parameter to `fit_model` (default to NULL), adding contrasts to `data_args_default` and adding contrasts as a parameter to `make_covariates`, eventually used in call to `model.matrix`